### PR TITLE
Updated distance recovery calculation

### DIFF
--- a/StageRecovery/RecoveryItem.cs
+++ b/StageRecovery/RecoveryItem.cs
@@ -682,20 +682,14 @@ namespace StageRecovery
             //Calculate the max distance from KSC (half way around a circle the size of Kerbin)
             double maxDist = SpaceCenter.Instance.cb.Radius * Math.PI;
 
-            int TSUpgrades = StageRecovery.BuildingUpgradeLevel(SpaceCenterFacility.TrackingStation);
-            if (TSUpgrades == 0)
-            {
-                maxDist *= (0.5);
-            }
-            else if (TSUpgrades == 1)
-            {
-                maxDist *= (0.75);
-            }
-
             //Get the reduction in returns due to distance (0.98 at KSC, .1 at maxDist)
             if (!Settings1.Instance.UseDistanceOverride)
             {
-                DistancePercent = Mathf.Lerp(0.98f, 0.1f, (float)(KSCDistance / maxDist));
+                DistancePercent = Mathf.Lerp(
+                    Math.Max(0.0f, Math.Min(1f, 0.98f + ValueModifierQuery.RunQuery("RecoveryMaximumDelta", 1f).GetEffectDelta())),
+                    Math.Max(0.0f, Math.Min(1f, 0.1f + ValueModifierQuery.RunQuery("RecoveryMinimumDelta", 1f).GetEffectDelta())),
+                    (float) (KSCDistance / maxDist)
+                );
             }
             else
             {


### PR DESCRIPTION
The biggest improvement here is that if someone made a mod or Strategia config that modified "RecoveryMaximumDelta" or "RecoveryMinimumDelta", it would be respected by StageRecovery now.

In the same spirit of emulating stock behavior, I killed the maximum distance is a factor of Tracking Station level logic. This is not present in stock and as far as I can tell, is only briefly documented in the changelog from 4/8/2015. As written, wasn't great for compatibility with CustomBarnKit, either. The clamping behavior of Mathf.Lerp is probably not intuitive to many users.

The only behavior missing from stock is the complete refund from landing at any runway or launchpad mini-biome. I would think this is intentional, since the chances of getting your discarded stage on rails to a mini-biome seem slim. Plus, this would be a PITA to check.