### PR TITLE
Change a couple of error logs to info logs to stop log spam.

### DIFF
--- a/StageRecovery/RecoveryControllerWrapper.cs
+++ b/StageRecovery/RecoveryControllerWrapper.cs
@@ -131,7 +131,7 @@ namespace StageRecovery
             var s = CallRecoveryController("RegisterMod", modName);
             if (s == null)
             {
-                Log.Error("RegisterMod, CallRecoveryController returned null");
+                Log.Info("RegisterMod, CallRecoveryController returned null");
                 return false;
             }
             Log.Info("RegisterMod returning: " + ((bool)s).ToString());

--- a/StageRecovery/StageRecovery.cs
+++ b/StageRecovery/StageRecovery.cs
@@ -163,11 +163,11 @@ namespace StageRecovery
         }
         void onVesselRecovered(ProtoVessel pv, bool b)
         {
-            Log.Error("onVesselRecovered: " + pv.vesselName);
+            Log.Info("onVesselRecovered: " + pv.vesselName);
         }
         void onVesselTerminated(ProtoVessel pv)
         {
-            Log.Error("onVesselTerminated: " + pv.vesselName);
+            Log.Info("onVesselTerminated: " + pv.vesselName);
         }
 
         public void ShipModifiedEvent(ShipConstruct sc)


### PR DESCRIPTION
(cherry picked from commit 87479da396aca0cd95f740c3cb4ae3c6a0089c17)

This patch converts a couple of Log.Error lines into Log.Info, reducing log spam especially when using the debug build of the Unity Player.  When using the Debug Player, error logs show up in a pop-up window.  I think these particular messages are informational rather than actual errors.